### PR TITLE
[feat]新增密碼顯示切換功能&優化登入/註冊css樣式

### DIFF
--- a/users/templates/users/login.html
+++ b/users/templates/users/login.html
@@ -1,22 +1,23 @@
 {% load socialaccount %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-TW">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PicTrace</title>
+    <title>PicTrace - 登入</title>
     {% load static %}
     <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
   </head>
+
   {% include "shared/navbar2.html" %}
+
   <body
     class="flex items-center justify-center h-screen bg-center bg-cover"
     style="background-image: url('{% static 'images/background.jpg' %}')"
   >
     <div
-      class="w-full max-w-md px-8 pt-6 pb-8 mb-4 bg-white rounded-lg shadow-md"
+      class="w-full max-w-md px-8 pt-6 pb-2 mb-4 bg-white rounded-lg shadow-md"
     >
-      <!-- Header with back arrow and title -->
       <div class="relative mb-4">
         <!-- Back Arrow -->
         <a
@@ -42,7 +43,8 @@
         <!-- Login Title -->
         <h1 class="text-2xl font-bold text-center text-gray-700">登入</h1>
       </div>
-      <!-- Login Form -->
+
+      <!-- Error Messages -->
       {% if messages %}
       <div class="mb-4">
         {% for message in messages %}
@@ -52,57 +54,57 @@
         {% endfor %}
       </div>
       {% endif %}
+
+      <!-- Login Form -->
       <form method="post" action="{% url 'users:login' %}">
         {% csrf_token %}
+
+        <!-- Username -->
         <div class="mb-4">
           <label
             for="username"
             class="block mb-2 text-sm font-bold text-gray-700"
-            >帳戶</label
+            >用戶名</label
           >
           <input
             type="text"
             name="username"
             id="username"
             class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
-            placeholder=""
             required
           />
         </div>
+
+        <!-- Password -->
         <div class="mb-6">
           <label
             for="password"
             class="flex mb-2 text-sm font-bold text-gray-700"
-            >密碼<a
+            >密碼
+            <a
               href="{% url 'users:password_reset' %}"
               class="flex ml-auto text-blue-600 hover:underline"
               >忘記密碼？</a
             >
           </label>
-
           <input
             type="password"
             name="password"
             id="password"
             class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
-            placeholder=""
             required
           />
         </div>
-        <div class="flex items-center justify-between">
-          <button
-            type="submit"
-            class="px-4 py-2 font-bold text-white bg-blue-600 rounded hover:bg-blue-700 focus:outline-none focus:shadow-outline"
-          >
-            登入
-          </button>
-          <a
-            href="{% url 'users:register' %}"
-            class="inline-block text-sm font-bold text-blue-600 align-baseline hover:text-blue-800"
-          >
-            還沒有帳號嗎? 註冊
-          </a>
-        </div>
+
+        <!-- Login Button -->
+        <button
+          type="submit"
+          class="w-full px-4 py-2 font-bold text-white bg-blue-600 rounded hover:bg-blue-700 focus:outline-none focus:shadow-outline"
+        >
+          登入
+        </button>
+
+        <!-- 使用 Google 登入 -->
         <div class="flex justify-center mt-4">
           <a
             href="{% provider_login_url 'google' %}"
@@ -111,8 +113,25 @@
             使用 Google 登入
           </a>
         </div>
+
+        <!-- 分隔線 (更粗更深) -->
+        <hr class="my-4 border-gray-500 border-1" />
+
+        <!-- 註冊提示 (縮小字體 & 間距) -->
+        <div class="scroll-py-0.5 text-center">
+          <p class="text-sm text-gray-500">
+            還沒有帳號嗎？
+            <a
+              href="{% url 'users:register' %}"
+              class="text-blue-600 hover:underline"
+            >
+              註冊
+            </a>
+          </p>
+        </div>
       </form>
     </div>
+
     <!-- Footer -->
     <footer
       class="absolute bottom-0 left-0 right-0 flex justify-center py-2 text-center text-white bg-black"

--- a/users/templates/users/login.html
+++ b/users/templates/users/login.html
@@ -16,7 +16,7 @@
     style="background-image: url('{% static 'images/background.jpg' %}')"
   >
     <div
-      class="w-full max-w-md px-8 pt-6 pb-2 mb-4 bg-white rounded-lg shadow-md"
+      class="w-full max-w-md px-8 pt-6 pb-1 mb-4 bg-white rounded-lg shadow-md"
     >
       <div class="relative mb-4">
         <!-- Back Arrow -->
@@ -76,24 +76,81 @@
         </div>
 
         <!-- Password -->
-        <div class="mb-6">
+        <div class="relative mb-6">
           <label
             for="password"
             class="flex mb-2 text-sm font-bold text-gray-700"
-            >密碼
+          >
+            密碼
             <a
               href="{% url 'users:password_reset' %}"
               class="flex ml-auto text-blue-600 hover:underline"
-              >忘記密碼？</a
             >
+              忘記密碼？
+            </a>
           </label>
-          <input
-            type="password"
-            name="password"
-            id="password"
-            class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
-            required
-          />
+
+          <!-- 密碼輸入框 -->
+          <div class="relative">
+            <input
+              type="password"
+              name="password"
+              id="password"
+              class="w-full px-3 py-2 pr-10 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
+              required
+            />
+
+            <!-- 眼睛按鈕 -->
+            <span
+              id="togglePassword"
+              class="absolute inset-y-0 flex items-center text-gray-500 cursor-pointer right-3 hover:text-gray-700"
+              onclick="togglePassword()"
+            >
+              <!-- 預設眼睛圖示 (開啟) -->
+              <svg
+                id="eye-open"
+                xmlns="http://www.w3.org/2000/svg"
+                class="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M15.9 15.9A6 6 0 018 12a6 6 0 017.9-3.9"
+                />
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
+                />
+              </svg>
+
+              <!-- 隱藏眼睛圖示 (閉合) -->
+              <svg
+                id="eye-closed"
+                xmlns="http://www.w3.org/2000/svg"
+                class="hidden w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M17.94 17.94A9.99 9.99 0 0112 20C5 20 2 12 2 12s3-8 10-8c2.5 0 4.8.9 6.54 2.4"
+                />
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M9.88 9.88a3 3 0 014.24 4.24M3 3l18 18"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
 
         <!-- Login Button -->
@@ -114,12 +171,12 @@
           </a>
         </div>
 
-        <!-- 分隔線 (更粗更深) -->
+        <!-- 分隔線 -->
         <hr class="my-4 border-gray-500 border-1" />
 
-        <!-- 註冊提示 (縮小字體 & 間距) -->
-        <div class="scroll-py-0.5 text-center">
-          <p class="text-sm text-gray-500">
+        <!-- 註冊提示 -->
+        <div class="text-center">
+          <p class="px-4 text-gray-500">
             還沒有帳號嗎？
             <a
               href="{% url 'users:register' %}"
@@ -138,5 +195,24 @@
     >
       <p>&copy; 2025 PicTrace. All rights reserved.</p>
     </footer>
+
+    <!-- JavaScript for Toggle Password -->
+    <script>
+      function togglePassword() {
+        let passwordInput = document.getElementById("password");
+        let eyeOpen = document.getElementById("eye-open");
+        let eyeClosed = document.getElementById("eye-closed");
+
+        if (passwordInput.type === "password") {
+          passwordInput.type = "text";
+          eyeOpen.classList.add("hidden");
+          eyeClosed.classList.remove("hidden");
+        } else {
+          passwordInput.type = "password";
+          eyeOpen.classList.remove("hidden");
+          eyeClosed.classList.add("hidden");
+        }
+      }
+    </script>
   </body>
 </html>

--- a/users/templates/users/password_reset_confirm.html
+++ b/users/templates/users/password_reset_confirm.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-TW">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,7 +7,9 @@
     {% load static %}
     <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
   </head>
+
   {% include "shared/navbar2.html" %}
+
   <body
     class="flex items-center justify-center h-screen bg-center bg-cover"
     style="background-image: url('{% static 'images/background.jpg' %}')"
@@ -17,46 +19,143 @@
     >
       <!-- Header and title -->
       <div class="relative mb-4">
-        <!-- Reset Password Title -->
         <h1 class="text-2xl font-bold text-center text-gray-700">
           重置您的密碼
         </h1>
       </div>
+
       <!-- Reset Password Form -->
       <form method="post" class="space-y-6">
         {% csrf_token %}
+
         <div class="space-y-4">
+          <!-- New Password -->
           <div>
             <label
               for="id_new_password1"
               class="block text-sm font-medium text-gray-700"
+              >新密碼：</label
             >
-              新密碼：</label
-            >
-            <input
-              type="password"
-              name="new_password1"
-              id="id_new_password1"
-              class="block w-full px-3 py-2 mt-1 text-gray-700 placeholder-gray-400 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-              placeholder="新密碼須包含英文及數字"
-            />
+            <div class="relative">
+              <input
+                type="password"
+                name="new_password1"
+                id="id_new_password1"
+                class="w-full px-3 py-2 pr-10 mt-1 text-gray-700 placeholder-gray-400 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                placeholder="新密碼須包含英文及數字"
+              />
+              <span
+                onclick="togglePassword('id_new_password1')"
+                class="absolute inset-y-0 flex items-center text-gray-500 cursor-pointer right-3 hover:text-gray-700"
+              >
+                <svg
+                  id="eye-open-id_new_password1"
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M15.9 15.9A6 6 0 018 12a6 6 0 017.9-3.9"
+                  />
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
+                  />
+                </svg>
+                <svg
+                  id="eye-closed-id_new_password1"
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="hidden w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M17.94 17.94A9.99 9.99 0 0112 20C5 20 2 12 2 12s3-8 10-8c2.5 0 4.8.9 6.54 2.4"
+                  />
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M9.88 9.88a3 3 0 014.24 4.24M3 3l18 18"
+                  />
+                </svg>
+              </span>
+            </div>
           </div>
+
+          <!-- Confirm New Password -->
           <div>
             <label
               for="id_new_password2"
               class="block text-sm font-medium text-gray-700"
+              >新密碼確認：</label
             >
-              新密碼確認：</label
-            >
-            <input
-              type="password"
-              name="new_password2"
-              id="id_new_password2"
-              class="block w-full px-3 py-2 mt-1 text-gray-700 placeholder-gray-400 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-              placeholder="請再次輸入新密碼"
-            />
+            <div class="relative">
+              <input
+                type="password"
+                name="new_password2"
+                id="id_new_password2"
+                class="w-full px-3 py-2 pr-10 mt-1 text-gray-700 placeholder-gray-400 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                placeholder="請再次輸入新密碼"
+              />
+              <span
+                onclick="togglePassword('id_new_password2')"
+                class="absolute inset-y-0 flex items-center text-gray-500 cursor-pointer right-3 hover:text-gray-700"
+              >
+                <svg
+                  id="eye-open-id_new_password2"
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M15.9 15.9A6 6 0 018 12a6 6 0 017.9-3.9"
+                  />
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
+                  />
+                </svg>
+                <svg
+                  id="eye-closed-id_new_password2"
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="hidden w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M17.94 17.94A9.99 9.99 0 0112 20C5 20 2 12 2 12s3-8 10-8c2.5 0 4.8.9 6.54 2.4"
+                  />
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M9.88 9.88a3 3 0 014.24 4.24M3 3l18 18"
+                  />
+                </svg>
+              </span>
+            </div>
           </div>
         </div>
+
         <button
           type="submit"
           class="w-full px-4 py-2 text-white bg-blue-600 rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
@@ -64,18 +163,31 @@
           修改密碼
         </button>
       </form>
+
       <p class="mt-4 text-sm text-center text-gray-600">
         想起密碼了嗎？
-        <a href="{% url 'users:login' %}" class="text-blue-500 hover:underline">
-          返回登入頁面
-        </a>
+        <a href="{% url 'users:login' %}" class="text-blue-500 hover:underline"
+          >返回登入頁面</a
+        >
       </p>
     </div>
+
     <!-- Footer -->
     <footer
       class="absolute bottom-0 left-0 right-0 flex justify-center py-2 text-center text-white bg-black"
     >
       <p>&copy; 2025 PicTrace. All rights reserved.</p>
     </footer>
+
+    <!-- JavaScript for Toggle Password -->
+    <script>
+      function togglePassword(id) {
+        let passwordInput = document.getElementById(id);
+        document.getElementById("eye-open-" + id).classList.toggle("hidden");
+        document.getElementById("eye-closed-" + id).classList.toggle("hidden");
+        passwordInput.type =
+          passwordInput.type === "password" ? "text" : "password";
+      }
+    </script>
   </body>
 </html>

--- a/users/templates/users/register.html
+++ b/users/templates/users/register.html
@@ -217,6 +217,14 @@
             </span>
           </div>
         </div>
+        <button
+          type="submit"
+          class="w-full px-4 py-2 text-white bg-blue-600 rounded-lg hover:bg-blue-500"
+        >
+          註冊
+        </button>
+        <!-- 分隔線 -->
+        <hr class="my-4 border-gray-500 border-1" />
       </form>
     </div>
 

--- a/users/templates/users/register.html
+++ b/users/templates/users/register.html
@@ -95,12 +95,13 @@
           <label
             for="password1"
             class="block mb-2 text-sm font-bold text-gray-700"
-            >密碼（至少 8 位數）</label
+            >密碼</label
           >
           <input
             type="password"
             name="password1"
             id="password1"
+            placeholder="密碼須包含英文及數字"
             class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
             required
             minlength="8"
@@ -117,6 +118,7 @@
             type="password"
             name="password2"
             id="password2"
+            placeholder="請再次輸入密碼"
             class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
             required
             minlength="8"

--- a/users/templates/users/register.html
+++ b/users/templates/users/register.html
@@ -1,13 +1,15 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-TW">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PicTrace</title>
+    <title>PicTrace - 註冊</title>
     {% load static %}
     <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
   </head>
+
   {% include "shared/navbar2.html" %}
+
   <body
     class="flex items-center justify-center h-screen bg-center bg-cover"
     style="background-image: url('{% static 'images/background.jpg' %}')"
@@ -15,9 +17,8 @@
     <div
       class="w-full max-w-md px-8 pt-6 pb-8 mb-4 bg-white rounded-lg shadow-md"
     >
-      <!-- Header with back arrow and title -->
+      <!-- Header -->
       <div class="relative mb-4">
-        <!-- Back Arrow -->
         <a
           href="{% url 'home:home' %}"
           class="absolute left-0 flex items-center text-gray-600 transform -translate-y-1/2 top-1/2 hover:text-blue-800"
@@ -38,10 +39,9 @@
             />
           </svg>
         </a>
-        <!-- Register Title -->
         <h1 class="text-2xl font-bold text-center text-gray-700">註冊帳號</h1>
       </div>
-      <!-- Register Form -->
+
       <!-- Error Messages -->
       {% if form.errors %}
       <div class="p-4 mb-4 text-red-700 bg-red-100 rounded-lg">
@@ -53,16 +53,10 @@
       </div>
       {% endif %}
 
-      <!-- Success Message -->
-      {% if messages %}
-      <div class="p-4 mb-4 text-green-700 bg-green-100 rounded-lg">
-        {% for message in messages %}
-        <p>{{ message }}</p>
-        {% endfor %}
-      </div>
-      {% endif %}
       <form method="post" action="{% url 'users:register' %}">
         {% csrf_token %}
+
+        <!-- Username -->
         <div class="mb-4">
           <label
             for="username"
@@ -78,6 +72,8 @@
             required
           />
         </div>
+
+        <!-- Email -->
         <div class="mb-4">
           <label for="email" class="block mb-2 text-sm font-bold text-gray-700"
             >信箱</label
@@ -91,64 +87,147 @@
             required
           />
         </div>
+
+        <!-- Password -->
         <div class="mb-6">
           <label
             for="password1"
             class="block mb-2 text-sm font-bold text-gray-700"
             >密碼</label
           >
-          <input
-            type="password"
-            name="password1"
-            id="password1"
-            placeholder="密碼須包含英文及數字"
-            class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
-            required
-            minlength="8"
-          />
+          <div class="relative">
+            <input
+              type="password"
+              name="password1"
+              id="password1"
+              placeholder="密碼須包含英文及數字"
+              class="w-full px-3 py-2 pr-10 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
+              required
+              minlength="8"
+            />
+            <span
+              onclick="togglePassword('password1')"
+              class="absolute inset-y-0 flex items-center text-gray-500 cursor-pointer right-3 hover:text-gray-700"
+            >
+              <svg
+                id="eye-open-password1"
+                xmlns="http://www.w3.org/2000/svg"
+                class="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M15.9 15.9A6 6 0 018 12a6 6 0 017.9-3.9"
+                />
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
+                />
+              </svg>
+              <svg
+                id="eye-closed-password1"
+                xmlns="http://www.w3.org/2000/svg"
+                class="hidden w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M17.94 17.94A9.99 9.99 0 0112 20C5 20 2 12 2 12s3-8 10-8c2.5 0 4.8.9 6.54 2.4"
+                />
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M9.88 9.88a3 3 0 014.24 4.24M3 3l18 18"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
 
+        <!-- Confirm Password -->
         <div class="mb-6">
           <label
             for="password2"
             class="block mb-2 text-sm font-bold text-gray-700"
             >確認密碼</label
           >
-          <input
-            type="password"
-            name="password2"
-            id="password2"
-            placeholder="請再次輸入密碼"
-            class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
-            required
-            minlength="8"
-          />
+          <div class="relative">
+            <input
+              type="password"
+              name="password2"
+              id="password2"
+              placeholder="請再次輸入密碼"
+              class="w-full px-3 py-2 pr-10 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
+              required
+              minlength="8"
+            />
+            <span
+              onclick="togglePassword('password2')"
+              class="absolute inset-y-0 flex items-center text-gray-500 cursor-pointer right-3 hover:text-gray-700"
+            >
+              <svg
+                id="eye-open-password2"
+                xmlns="http://www.w3.org/2000/svg"
+                class="w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M15.9 15.9A6 6 0 018 12a6 6 0 017.9-3.9"
+                />
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
+                />
+              </svg>
+              <svg
+                id="eye-closed-password2"
+                xmlns="http://www.w3.org/2000/svg"
+                class="hidden w-6 h-6"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M17.94 17.94A9.99 9.99 0 0112 20C5 20 2 12 2 12s3-8 10-8c2.5 0 4.8.9 6.54 2.4"
+                />
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M9.88 9.88a3 3 0 014.24 4.24M3 3l18 18"
+                />
+              </svg>
+            </span>
+          </div>
         </div>
-
-        <button
-          type="submit"
-          class="w-full px-4 py-2 text-white bg-blue-600 rounded-lg hover:bg-blue-500"
-        >
-          註冊
-        </button>
       </form>
-
-      <div class="mt-4 text-center">
-        <p class="text-sm text-gray-500">
-          已經有帳號？
-          <a
-            href="{% url 'users:login' %}"
-            class="text-blue-600 hover:underline"
-            >登入</a
-          >
-        </p>
-      </div>
     </div>
-    <!-- Footer -->
-    <footer
-      class="absolute bottom-0 left-0 right-0 flex justify-center py-2 text-center text-white bg-black"
-    >
-      <p>&copy; 2025 PicTrace. All rights reserved.</p>
-    </footer>
+
+    <script>
+      function togglePassword(id) {
+        let passwordInput = document.getElementById(id);
+        document.getElementById("eye-open-" + id).classList.toggle("hidden");
+        document.getElementById("eye-closed-" + id).classList.toggle("hidden");
+        passwordInput.type =
+          passwordInput.type === "password" ? "text" : "password";
+      }
+    </script>
   </body>
 </html>

--- a/users/templates/users/register.html
+++ b/users/templates/users/register.html
@@ -15,7 +15,7 @@
     style="background-image: url('{% static 'images/background.jpg' %}')"
   >
     <div
-      class="w-full max-w-md px-8 pt-6 pb-8 mb-4 bg-white rounded-lg shadow-md"
+      class="w-full max-w-md px-8 pt-6 pb-2 mb-4 bg-white rounded-lg shadow-md"
     >
       <!-- Header -->
       <div class="relative mb-4">
@@ -225,6 +225,17 @@
         </button>
         <!-- 分隔線 -->
         <hr class="my-4 border-gray-500 border-1" />
+
+        <div class="text-center">
+          <p class="px-4 text-gray-500">
+            已經有帳號？
+            <a
+              href="{% url 'users:login' %}"
+              class="text-blue-600 hover:underline"
+              >登入</a
+            >
+          </p>
+        </div>
       </form>
     </div>
 


### PR DESCRIPTION
## 變更內容
1. 新增密碼顯示/隱藏功能
- 在 login.html、register.html 和 password_reset_confirm.html 頁面中，新增了「小眼睛」功能。
- 使用者可以透過點擊圖示顯示或隱藏密碼，提升使用者體驗及密碼輸入的便利性。

2. 修正樣式

- 調整了 login.html 和 register.html 的 CSS 樣式，使整體設計更加一致和美觀。
- 使用 Tailwind CSS 進行樣式更新，改善元件的邊距、字體及配色。
- 修正 register.html的placehold欄位顯示

## 優化細節

- 新增的「小眼睛」功能使用 JavaScript 實現，透過 togglePassword() 函數切換密碼輸入框的 type 屬性。
- 增加了 SVG 圖示以提供視覺上的提示，並確保在各種裝置和瀏覽器中的一致性。

## 測試

- 已在本地環境測試以下功能：
- 密碼顯示/隱藏切換功能正常運作。
- 登入、註冊及重設密碼流程不受影響。


## 影響範圍

- 此PR主要影響使用者認證相關的頁面及其樣式設定，不會對其他功能造成影響。

<img width="472" alt="截圖 2025-02-03 下午4 08 15" src="https://github.com/user-attachments/assets/7fd38345-1b10-4b20-a983-bd5706fee9b9" />

<img width="472" alt="截圖 2025-02-03 下午4 09 26" src="https://github.com/user-attachments/assets/b3b132f7-b8df-49b2-8fa0-9aa523c00367" />

