### PR TITLE
[feat]新增註冊後的電子郵件驗證頁面並進行重定向

### DIFF
--- a/users/templates/users/check_email.html
+++ b/users/templates/users/check_email.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PicTrace - 檢查電子郵件</title>
+    {% load static %}
+    <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
+  </head>
+  {% include "shared/navbar2.html" %}
+
+  <body
+    class="flex items-center justify-center h-screen bg-center bg-cover"
+    style="background-image: url('{% static 'images/background.jpg' %}')"
+  >
+    <div
+      class="w-full max-w-md px-8 pt-6 pb-8 mb-4 text-center bg-white rounded-lg shadow-md"
+    >
+      <h1 class="text-2xl font-bold text-gray-700">檢查你的收件箱</h1>
+      <p class="mt-2 text-gray-600">
+        我們已將驗證郵件發送至
+        <span class="font-bold text-gray-800">{{ email }}</span>
+      </p>
+      <p class="mt-2 text-gray-600">請檢查您的信箱以完成註冊。</p>
+      <a
+        href="{% url 'users:login' %}"
+        class="block w-full px-4 py-2 mt-4 font-bold text-white bg-blue-600 rounded-lg hover:bg-blue-700"
+      >
+        返回登入頁面
+      </a>
+    </div>
+  </body>
+</html>

--- a/users/templates/users/check_email.html
+++ b/users/templates/users/check_email.html
@@ -8,7 +8,6 @@
     <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
   </head>
   {% include "shared/navbar2.html" %}
-
   <body
     class="flex items-center justify-center h-screen bg-center bg-cover"
     style="background-image: url('{% static 'images/background.jpg' %}')"
@@ -22,12 +21,26 @@
         <span class="font-bold text-gray-800">{{ email }}</span>
       </p>
       <p class="mt-2 text-gray-600">請檢查您的信箱以完成註冊。</p>
+
+      <!-- 返回登入頁面按鈕 -->
       <a
         href="{% url 'users:login' %}"
         class="block w-full px-4 py-2 mt-4 font-bold text-white bg-blue-600 rounded-lg hover:bg-blue-700"
       >
         返回登入頁面
       </a>
+
+      <!-- 重新發送驗證郵件按鈕 -->
+      <form method="post" action="{% url 'users:resend_verification' %}">
+        {% csrf_token %}
+        <input type="hidden" name="email" value="{{ email }}" />
+        <button
+          type="submit"
+          class="block w-full px-4 py-2 mt-4 font-bold text-white bg-gray-600 rounded-lg hover:bg-gray-700"
+        >
+          重新發送驗證郵件
+        </button>
+      </form>
     </div>
   </body>
 </html>

--- a/users/urls.py
+++ b/users/urls.py
@@ -31,4 +31,5 @@ urlpatterns = [
         views.CustomPasswordResetCompleteView.as_view(),
         name="password_reset_complete",
     ),
+    path("check-email/", views.check_email_view, name="check_email"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/users/urls.py
+++ b/users/urls.py
@@ -32,4 +32,9 @@ urlpatterns = [
         name="password_reset_complete",
     ),
     path("check-email/", views.check_email_view, name="check_email"),
+    path(
+        "resend-verification/",
+        views.resend_verification_email_view,
+        name="resend_verification",
+    ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/users/views.py
+++ b/users/views.py
@@ -97,12 +97,20 @@ def register_view(request):
             email_msg.content_subtype = "html"  # 設置為 HTML 格式
             email_msg.send()
 
-            messages.success(request, "註冊成功！請檢查您的信箱，完成帳號驗證。")
-            return redirect("users:login")
+            # 轉向檢查信箱頁面，並帶上 email 參數
+            return redirect(f"{reverse_lazy('users:check_email')}?email={email}")
+
     else:
         form = SimpleUserCreationForm()
 
     return render(request, "users/register.html", {"form": form})
+
+
+# 檢查電子郵件的頁面
+def check_email_view(request):
+    """顯示檢查電子郵件的頁面"""
+    email = request.GET.get("email")  # 取得用戶註冊時的 email
+    return render(request, "users/check_email.html", {"email": email})
 
 
 # 登出


### PR DESCRIPTION
## 變更內容
1. 新增電子郵件驗證頁面 (check_email.html)
- 註冊後，使用者會被導向該頁面，提醒他們檢查信箱完成帳戶驗證。
- 顯示註冊時使用的電子郵件地址，提升使用者體驗。

2. 修改 register_view
- 註冊成功後，不再顯示 messages.success 訊息，而是導向 check_email 頁面。
- 透過 URL 參數 (email) 傳遞使用者的電子郵件地址。

3. 新增 check_email_view
- 解析 URL 參數中的 email，並渲染 check_email.html 頁面。

4. 更新 urls.py
- 新增 check_email/ 路由，對應到 check_email_view。

5. 新增「重新發送驗證郵件」按鈕

- 在 check_email.html 頁面上新增一個按鈕，允許使用者點擊後重新發送驗證信。
- 按鈕點擊後會向後端發送請求，觸發重新寄送驗證信的流程。
- 確保按鈕樣式與 UI 設計一致，且提供明確的操作提示。

## 變更原因
- 讓使用者在註冊後清楚知道他們需要前往電子郵件收信，避免混淆。
- 提供更直覺的流程，避免直接導向登入頁面可能產生的不便。
- 若使用者未收到驗證信，或誤刪信件，提供一個簡單的方式讓使用者請求重新發送，提升使用體驗。

## 影響範圍

- 註冊流程 (register_view)
- 新增的 check_email 頁面和對應的 URL
- views.py 和 urls.py 變更

## 測試方式

- 註冊新帳號後，應被導向 check_email.html，並顯示使用者的電子郵件。
- 確保電子郵件連結仍然有效，並能夠完成帳戶驗證流程。
- 測試點擊「再次發送驗證信」按鈕，是否能夠重新寄送驗證信至對應的電子郵件。

<img width="478" alt="截圖 2025-02-03 下午4 52 30" src="https://github.com/user-attachments/assets/9a63ad34-6965-43fd-b1c5-657a5e94bcc8" />

