### PR TITLE
[refactor]抽離 Footer 成為可重用模板並優化響應式設計

### DIFF
--- a/home/templates/home/home.html
+++ b/home/templates/home/home.html
@@ -1,30 +1,27 @@
 {% extends "shared/layout.html" %} {% load static %} {% block content %}
-<!-- Main Content -->
-<main class="pt-16">
-  <div class="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
-    <h1 class="mb-8 text-4xl font-bold text-center">歡迎來到 PicTrace！</h1>
+<div class="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
+  <h1 class="mb-8 text-4xl font-bold text-center">歡迎來到 PicTrace！</h1>
 
-    <!-- Features Section -->
-    <section class="grid grid-cols-1 gap-12 md:grid-cols-2 lg:grid-cols-3">
-      <div class="p-6 bg-white rounded-lg shadow-lg">
-        <h2 class="text-2xl font-semibold">發現台灣景點</h2>
-        <p class="mt-4 text-gray-600">
-          在地標註你拍攝過的景點，並探索更多美麗的場所。
-        </p>
-      </div>
-      <div class="p-6 bg-white rounded-lg shadow-lg">
-        <h2 class="text-2xl font-semibold">照片分享</h2>
-        <p class="mt-4 text-gray-600">
-          將你的照片上傳與社群分享，建立自己的影像庫。
-        </p>
-      </div>
-      <div class="p-6 bg-white rounded-lg shadow-lg">
-        <h2 class="text-2xl font-semibold">用戶活動</h2>
-        <p class="mt-4 text-gray-600">
-          參與我們的拍攝主題活動，並有機會贏得獎品。
-        </p>
-      </div>
-    </section>
-  </div>
-</main>
+  <!-- Features Section -->
+  <section class="grid grid-cols-1 gap-12 md:grid-cols-2 lg:grid-cols-3">
+    <div class="p-6 bg-white rounded-lg shadow-lg">
+      <h2 class="text-2xl font-semibold">發現台灣景點</h2>
+      <p class="mt-4 text-gray-600">
+        在地標註你拍攝過的景點，並探索更多美麗的場所。
+      </p>
+    </div>
+    <div class="p-6 bg-white rounded-lg shadow-lg">
+      <h2 class="text-2xl font-semibold">照片分享</h2>
+      <p class="mt-4 text-gray-600">
+        將你的照片上傳與社群分享，建立自己的影像庫。
+      </p>
+    </div>
+    <div class="p-6 bg-white rounded-lg shadow-lg">
+      <h2 class="text-2xl font-semibold">用戶活動</h2>
+      <p class="mt-4 text-gray-600">
+        參與我們的拍攝主題活動，並有機會贏得獎品。
+      </p>
+    </div>
+  </section>
+</div>
 {% endblock %}

--- a/templates/shared/footer.html
+++ b/templates/shared/footer.html
@@ -1,0 +1,5 @@
+<footer
+  class="flex justify-center w-full py-2 mt-auto text-center text-white bg-black"
+>
+  <p>&copy; 2025 PicTrace. All rights reserved.</p>
+</footer>

--- a/templates/shared/layout.html
+++ b/templates/shared/layout.html
@@ -7,7 +7,13 @@
     {% load static %}
     <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
   </head>
-  <body>
-    {%include "shared/navbar.html"%} {%block content %}{% endblock%}
+  <body class="flex flex-col min-h-screen">
+    {% include "shared/navbar.html" %}
+
+    <main class="flex flex-col flex-grow">
+      {% block content %}{% endblock %}
+    </main>
+
+    {% include "shared/footer.html" %}
   </body>
 </html>

--- a/users/templates/users/check_email.html
+++ b/users/templates/users/check_email.html
@@ -7,40 +7,52 @@
     {% load static %}
     <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
   </head>
-  {% include "shared/navbar2.html" %}
+
   <body
-    class="flex flex-col items-center justify-center min-h-screen bg-center bg-cover pt-14"
+    class="flex flex-col min-h-screen pt-16 bg-center bg-cover"
     style="background-image: url('{% static 'images/background.jpg' %}')"
   >
-    <div
-      class="w-full max-w-md px-8 pt-6 pb-8 mb-4 text-center bg-white rounded-lg shadow-md"
-    >
-      <h1 class="text-2xl font-bold text-gray-700">檢查你的收件箱</h1>
-      <p class="mt-2 text-gray-600">
-        我們已將驗證郵件發送至
-        <span class="font-bold text-gray-800">{{ email }}</span>
-      </p>
-      <p class="mt-2 text-gray-600">請檢查您的信箱以完成註冊。</p>
+    {% include "shared/navbar2.html" %}
 
-      <!-- 返回登入頁面按鈕 -->
-      <a
-        href="{% url 'users:login' %}"
-        class="block w-full px-4 py-2 mt-4 font-bold text-white bg-blue-600 rounded-lg hover:bg-blue-700"
+    <main class="flex flex-col items-center justify-center flex-grow">
+      <div
+        class="w-full max-w-md px-8 pt-6 pb-8 text-center bg-white rounded-lg shadow-md"
       >
-        返回登入頁面
-      </a>
+        <!-- Header -->
+        <h1 class="text-2xl font-bold text-gray-700">檢查你的收件箱</h1>
 
-      <!-- 重新發送驗證郵件按鈕 -->
-      <form method="post" action="{% url 'users:resend_verification' %}">
-        {% csrf_token %}
-        <input type="hidden" name="email" value="{{ email }}" />
-        <button
-          type="submit"
-          class="block w-full px-4 py-2 mt-4 font-bold text-white bg-gray-600 rounded-lg hover:bg-gray-700"
-        >
-          重新發送驗證郵件
-        </button>
-      </form>
-    </div>
+        <!-- Message -->
+        <p class="mt-2 text-gray-600">
+          我們已將驗證郵件發送至
+          <span class="font-bold text-gray-800">{{ email }}</span>
+        </p>
+        <p class="mt-2 text-gray-600">請檢查您的信箱以完成註冊。</p>
+
+        <!-- 按鈕組 -->
+        <div class="mt-4 space-y-3">
+          <!-- 返回登入頁面按鈕 -->
+          <a
+            href="{% url 'users:login' %}"
+            class="block w-full px-4 py-2 font-bold text-white bg-blue-600 rounded-lg hover:bg-blue-700"
+          >
+            返回登入頁面
+          </a>
+
+          <!-- 重新發送驗證郵件按鈕 -->
+          <form method="post" action="{% url 'users:resend_verification' %}">
+            {% csrf_token %}
+            <input type="hidden" name="email" value="{{ email }}" />
+            <button
+              type="submit"
+              class="block w-full px-4 py-2 font-bold text-white bg-gray-600 rounded-lg hover:bg-gray-700"
+            >
+              重新發送驗證郵件
+            </button>
+          </form>
+        </div>
+      </div>
+    </main>
+
+    {% include "shared/footer.html" %}
   </body>
 </html>

--- a/users/templates/users/login.html
+++ b/users/templates/users/login.html
@@ -9,89 +9,88 @@
     <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
   </head>
 
-  {% include "shared/navbar2.html" %}
-
   <body
-    class="flex flex-col items-center justify-center min-h-screen bg-center bg-cover pt-14"
+    class="flex flex-col min-h-screen bg-center bg-cover"
     style="background-image: url('{% static 'images/background.jpg' %}')"
   >
-    <div
-      class="w-full max-w-md px-8 pt-6 pb-1 mb-4 bg-white rounded-lg shadow-md"
-    >
-      <div class="relative mb-4">
-        <!-- Back Arrow -->
-        <a
-          href="{% url 'home:home' %}"
-          class="absolute left-0 flex items-center text-gray-600 transform -translate-y-1/2 top-1/2 hover:text-blue-800"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="w-8 h-8"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            viewBox="0 0 24 24"
+    {% include "shared/navbar2.html" %}
+
+    <!-- Main Content -->
+    <main class="flex flex-col items-center justify-center flex-grow pt-16">
+      <div class="w-full max-w-md px-8 pt-6 pb-4 bg-white rounded-lg shadow-md">
+        <div class="relative mb-4">
+          <!-- Back Arrow -->
+          <a
+            href="{% url 'home:home' %}"
+            class="absolute left-0 flex items-center text-gray-600 transform -translate-y-1/2 top-1/2 hover:text-blue-800"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M19 12H5" />
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M12 5l-7 7 7 7"
-            />
-          </svg>
-        </a>
-        <!-- Login Title -->
-        <h1 class="text-2xl font-bold text-center text-gray-700">登入</h1>
-      </div>
-
-      <!-- Error Messages -->
-      {% if messages %}
-      <div class="mb-4">
-        {% for message in messages %}
-        <p class="mb-2 text-sm font-bold text-center text-red-500">
-          {{ message }}
-        </p>
-        {% endfor %}
-      </div>
-      {% endif %}
-
-      <!-- Login Form -->
-      <form method="post" action="{% url 'users:login' %}">
-        {% csrf_token %}
-
-        <!-- Username -->
-        <div class="mb-4">
-          <label
-            for="username"
-            class="block mb-2 text-sm font-bold text-gray-700"
-            >用戶名</label
-          >
-          <input
-            type="text"
-            name="username"
-            id="username"
-            class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
-            required
-          />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="w-8 h-8"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M19 12H5"
+              />
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M12 5l-7 7 7 7"
+              />
+            </svg>
+          </a>
+          <h1 class="text-2xl font-bold text-center text-gray-700">登入</h1>
         </div>
 
-        <!-- Password -->
-        <div class="relative mb-6">
-          <label
-            for="password"
-            class="flex mb-2 text-sm font-bold text-gray-700"
-          >
-            密碼
-            <a
-              href="{% url 'users:password_reset' %}"
-              class="flex ml-auto text-blue-600 hover:underline"
-            >
-              忘記密碼？
-            </a>
-          </label>
+        <!-- Error Messages -->
+        {% if messages %}
+        <div class="mb-4">
+          {% for message in messages %}
+          <p class="mb-2 text-sm font-bold text-center text-red-500">
+            {{ message }}
+          </p>
+          {% endfor %}
+        </div>
+        {% endif %}
 
-          <!-- 密碼輸入框 -->
-          <div class="relative">
+        <!-- Login Form -->
+        <form method="post" action="{% url 'users:login' %}">
+          {% csrf_token %}
+
+          <!-- Username -->
+          <div class="mb-4">
+            <label
+              for="username"
+              class="block mb-2 text-sm font-bold text-gray-700"
+              >用戶名</label
+            >
+            <input
+              type="text"
+              name="username"
+              id="username"
+              class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
+              required
+            />
+          </div>
+
+          <!-- Password -->
+          <div class="relative mb-6">
+            <label
+              for="password"
+              class="flex mb-2 text-sm font-bold text-gray-700"
+            >
+              密碼
+              <a
+                href="{% url 'users:password_reset' %}"
+                class="flex ml-auto text-blue-600 hover:underline"
+                >忘記密碼？</a
+              >
+            </label>
             <input
               type="password"
               name="password"
@@ -99,120 +98,42 @@
               class="w-full px-3 py-2 pr-10 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
               required
             />
-
-            <!-- 眼睛按鈕 -->
-            <span
-              id="togglePassword"
-              class="absolute inset-y-0 flex items-center text-gray-500 cursor-pointer right-3 hover:text-gray-700"
-              onclick="togglePassword()"
-            >
-              <!-- 預設眼睛圖示 (開啟) -->
-              <svg
-                id="eye-open"
-                xmlns="http://www.w3.org/2000/svg"
-                class="w-6 h-6"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M15.9 15.9A6 6 0 018 12a6 6 0 017.9-3.9"
-                />
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
-                />
-              </svg>
-
-              <!-- 隱藏眼睛圖示 (閉合) -->
-              <svg
-                id="eye-closed"
-                xmlns="http://www.w3.org/2000/svg"
-                class="hidden w-6 h-6"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M17.94 17.94A9.99 9.99 0 0112 20C5 20 2 12 2 12s3-8 10-8c2.5 0 4.8.9 6.54 2.4"
-                />
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M9.88 9.88a3 3 0 014.24 4.24M3 3l18 18"
-                />
-              </svg>
-            </span>
           </div>
-        </div>
 
-        <!-- Login Button -->
-        <button
-          type="submit"
-          class="w-full px-4 py-2 font-bold text-white bg-blue-600 rounded hover:bg-blue-700 focus:outline-none focus:shadow-outline"
-        >
-          登入
-        </button>
-
-        <!-- 使用 Google 登入 -->
-        <div class="flex justify-center mt-4">
-          <a
-            href="{% provider_login_url 'google' %}"
-            class="px-4 py-2 font-bold text-white bg-red-600 rounded hover:bg-red-700"
+          <button
+            type="submit"
+            class="w-full px-4 py-2 font-bold text-white bg-blue-600 rounded hover:bg-blue-700 focus:outline-none focus:shadow-outline"
           >
-            使用 Google 登入
-          </a>
-        </div>
+            登入
+          </button>
 
-        <!-- 分隔線 -->
-        <hr class="my-4 border-gray-500 border-1" />
-
-        <!-- 註冊提示 -->
-        <div class="text-center">
-          <p class="px-4 text-gray-500">
-            還沒有帳號嗎？
+          <!-- 使用 Google 登入 -->
+          <div class="flex justify-center mt-4">
             <a
-              href="{% url 'users:register' %}"
-              class="text-blue-600 hover:underline"
+              href="{% provider_login_url 'google' %}"
+              class="px-4 py-2 font-bold text-white bg-red-600 rounded hover:bg-red-700"
             >
-              註冊
+              使用 Google 登入
             </a>
-          </p>
-        </div>
-      </form>
-    </div>
+          </div>
 
-    <!-- Footer -->
-    <footer
-      class="absolute bottom-0 left-0 right-0 flex justify-center py-2 text-center text-white bg-black"
-    >
-      <p>&copy; 2025 PicTrace. All rights reserved.</p>
-    </footer>
+          <hr class="my-4 border-gray-500 border-1" />
 
-    <!-- JavaScript for Toggle Password -->
-    <script>
-      function togglePassword() {
-        let passwordInput = document.getElementById("password");
-        let eyeOpen = document.getElementById("eye-open");
-        let eyeClosed = document.getElementById("eye-closed");
+          <!-- 註冊提示 -->
+          <div class="text-center">
+            <p class="px-4 text-gray-500">
+              還沒有帳號嗎？
+              <a
+                href="{% url 'users:register' %}"
+                class="text-blue-600 hover:underline"
+                >註冊</a
+              >
+            </p>
+          </div>
+        </form>
+      </div>
+    </main>
 
-        if (passwordInput.type === "password") {
-          passwordInput.type = "text";
-          eyeOpen.classList.add("hidden");
-          eyeClosed.classList.remove("hidden");
-        } else {
-          passwordInput.type = "password";
-          eyeOpen.classList.remove("hidden");
-          eyeClosed.classList.add("hidden");
-        }
-      }
-    </script>
+    {% include "shared/footer.html" %}
   </body>
 </html>

--- a/users/templates/users/password_reset.html
+++ b/users/templates/users/password_reset.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-TW">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,59 +7,73 @@
     {% load static %}
     <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
   </head>
-  {% include "shared/navbar2.html" %}
+
   <body
-    class="flex flex-col items-center justify-center min-h-screen bg-center bg-cover pt-14"
+    class="flex flex-col min-h-screen pt-16 bg-center bg-cover"
     style="background-image: url('{% static 'images/background.jpg' %}')"
   >
-    <div
-      class="w-full max-w-md px-8 pt-6 pb-8 mb-4 bg-white rounded-lg shadow-md"
-    >
-      <!-- Header and title -->
-      <div class="relative mb-4">
-        <!-- Reset Password Title -->
-        <h1 class="text-2xl font-bold text-center text-gray-700">重設密碼</h1>
-      </div>
-      <!-- Password Reset Form -->
-      <form method="post" action="{% url 'users:password_reset' %}">
-        {% csrf_token %}
-        <div class="mb-4">
-          <label for="email" class="block mb-2 text-sm font-bold text-gray-700"
-            >電子郵件地址</label
-          >
+    {% include "shared/navbar2.html" %}
 
-          <input
-            type="email"
-            name="email"
-            id="email"
-            class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
-            placeholder="請輸入您的電子郵件"
-            required
-          />
+    <main class="flex flex-col items-center justify-center flex-grow">
+      <div class="w-full max-w-md px-8 pt-6 pb-8 bg-white rounded-lg shadow-md">
+        <!-- Header -->
+        <div class="relative mb-4">
+          <h1 class="text-2xl font-bold text-center text-gray-700">重設密碼</h1>
         </div>
-        <div class="mb-6">
-          <button
-            type="submit"
-            class="w-full px-4 py-2 font-bold text-white bg-blue-600 rounded hover:bg-blue-700 focus:outline-none focus:shadow-outline"
-          >
-            發送重設密碼鏈接
-          </button>
+
+        <!-- ✅ 修正錯誤訊息 -->
+        {% if form.errors %}
+        <div class="p-4 mb-4 text-red-700 bg-red-100 rounded-lg">
+          <ul>
+            {% for error in form.non_field_errors %}
+            <li>{{ error }}</li>
+            {% endfor %} {% for field in form %} {% for error in field.errors %}
+            <li>{{ error }}</li>
+            {% endfor %} {% endfor %}
+          </ul>
         </div>
-        <div class="flex items-center justify-between">
-          <a
-            href="{% url 'users:login' %}"
-            class="inline-block text-sm font-bold text-blue-600 align-baseline hover:text-blue-800"
-          >
-            返回登入頁面
-          </a>
-        </div>
-      </form>
-    </div>
-    <!-- Footer -->
-    <footer
-      class="absolute bottom-0 left-0 right-0 flex justify-center py-2 text-center text-white bg-black"
-    >
-      <p>&copy; 2025 PicTrace. All rights reserved.</p>
-    </footer>
+        {% endif %}
+
+        <!-- Password Reset Form -->
+        <form method="post" action="{% url 'users:password_reset' %}">
+          {% csrf_token %}
+
+          <div class="mb-4">
+            <label
+              for="email"
+              class="block mb-2 text-sm font-bold text-gray-700"
+              >電子郵件地址</label
+            >
+            <input
+              type="email"
+              name="email"
+              id="email"
+              class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
+              placeholder="請輸入您的電子郵件"
+              required
+            />
+          </div>
+
+          <div class="mb-6">
+            <button
+              type="submit"
+              class="w-full px-4 py-2 font-bold text-white bg-blue-600 rounded hover:bg-blue-700 focus:outline-none focus:shadow-outline"
+            >
+              發送重設密碼鏈接
+            </button>
+          </div>
+
+          <div class="text-center">
+            <a
+              href="{% url 'users:login' %}"
+              class="text-blue-600 hover:underline"
+              >返回登入頁面</a
+            >
+          </div>
+        </form>
+      </div>
+    </main>
+
+    {% include "shared/footer.html" %}
   </body>
 </html>

--- a/users/templates/users/password_reset_complete.html
+++ b/users/templates/users/password_reset_complete.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-TW">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,40 +7,39 @@
     {% load static %}
     <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
   </head>
-  {% include "shared/navbar2.html" %}
+
   <body
-    class="flex flex-col items-center justify-center min-h-screen bg-center bg-cover pt-14"
+    class="flex flex-col min-h-screen pt-16 bg-center bg-cover"
     style="background-image: url('{% static 'images/background.jpg' %}')"
   >
-    <div
-      class="w-full max-w-md px-8 pt-6 pb-8 mb-4 bg-white rounded-lg shadow-md"
-    >
-      <!-- Header and title -->
-      <div class="relative mb-4">
-        <!-- Success Title -->
-        <h1 class="text-2xl font-bold text-center text-gray-700">
-          密碼重置成功
-        </h1>
+    {% include "shared/navbar2.html" %}
+
+    <main class="flex flex-col items-center justify-center flex-grow">
+      <div class="w-full max-w-md px-8 pt-6 pb-8 bg-white rounded-lg shadow-md">
+        <!-- Header -->
+        <div class="relative mb-4">
+          <h1 class="text-2xl font-bold text-center text-gray-700">
+            密碼重置成功
+          </h1>
+        </div>
+
+        <!-- Success Message -->
+        <p class="mb-6 text-center text-gray-500">
+          您的密碼已經成功重置，現在可以使用新密碼登入！
+        </p>
+
+        <!-- Button to go back to login -->
+        <div class="text-center">
+          <a
+            href="{% url 'users:login' %}"
+            class="inline-block px-6 py-2 text-white bg-blue-600 rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            返回登入頁面
+          </a>
+        </div>
       </div>
-      <!-- Success Message -->
-      <p class="mb-6 text-center text-gray-500">
-        您的密碼已經成功重置，您現在可以使用新密碼！
-      </p>
-      <!-- Button to go back to login -->
-      <div class="text-center">
-        <a
-          href="{% url 'users:login' %}"
-          class="inline-block px-6 py-2 text-white bg-blue-600 rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-        >
-          返回登入頁面
-        </a>
-      </div>
-    </div>
-    <!-- Footer -->
-    <footer
-      class="absolute bottom-0 left-0 right-0 flex justify-center py-2 text-center text-white bg-black"
-    >
-      <p>&copy; 2025 PicTrace. All rights reserved.</p>
-    </footer>
+    </main>
+
+    {% include "shared/footer.html" %}
   </body>
 </html>

--- a/users/templates/users/password_reset_confirm.html
+++ b/users/templates/users/password_reset_confirm.html
@@ -8,176 +8,177 @@
     <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
   </head>
 
-  {% include "shared/navbar2.html" %}
-
   <body
-    class="flex flex-col items-center justify-center min-h-screen bg-center bg-cover pt-14"
+    class="flex flex-col min-h-screen pt-16 bg-center bg-cover"
     style="background-image: url('{% static 'images/background.jpg' %}')"
   >
-    <div
-      class="w-full max-w-md px-8 pt-6 pb-8 mb-4 bg-white rounded-lg shadow-md"
-    >
-      <!-- Header and title -->
-      <div class="relative mb-4">
-        <h1 class="text-2xl font-bold text-center text-gray-700">
-          重置您的密碼
-        </h1>
-      </div>
+    {% include "shared/navbar2.html" %}
 
-      <!-- Reset Password Form -->
-      <form method="post" class="space-y-6">
-        {% csrf_token %}
-
-        <div class="space-y-4">
-          <!-- New Password -->
-          <div>
-            <label
-              for="id_new_password1"
-              class="block text-sm font-medium text-gray-700"
-              >新密碼：</label
-            >
-            <div class="relative">
-              <input
-                type="password"
-                name="new_password1"
-                id="id_new_password1"
-                class="w-full px-3 py-2 pr-10 mt-1 text-gray-700 placeholder-gray-400 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                placeholder="新密碼須包含英文及數字"
-              />
-              <span
-                onclick="togglePassword('id_new_password1')"
-                class="absolute inset-y-0 flex items-center text-gray-500 cursor-pointer right-3 hover:text-gray-700"
-              >
-                <svg
-                  id="eye-open-id_new_password1"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="w-6 h-6"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M15.9 15.9A6 6 0 018 12a6 6 0 017.9-3.9"
-                  />
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
-                  />
-                </svg>
-                <svg
-                  id="eye-closed-id_new_password1"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="hidden w-6 h-6"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M17.94 17.94A9.99 9.99 0 0112 20C5 20 2 12 2 12s3-8 10-8c2.5 0 4.8.9 6.54 2.4"
-                  />
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M9.88 9.88a3 3 0 014.24 4.24M3 3l18 18"
-                  />
-                </svg>
-              </span>
-            </div>
-          </div>
-
-          <!-- Confirm New Password -->
-          <div>
-            <label
-              for="id_new_password2"
-              class="block text-sm font-medium text-gray-700"
-              >新密碼確認：</label
-            >
-            <div class="relative">
-              <input
-                type="password"
-                name="new_password2"
-                id="id_new_password2"
-                class="w-full px-3 py-2 pr-10 mt-1 text-gray-700 placeholder-gray-400 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                placeholder="請再次輸入新密碼"
-              />
-              <span
-                onclick="togglePassword('id_new_password2')"
-                class="absolute inset-y-0 flex items-center text-gray-500 cursor-pointer right-3 hover:text-gray-700"
-              >
-                <svg
-                  id="eye-open-id_new_password2"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="w-6 h-6"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M15.9 15.9A6 6 0 018 12a6 6 0 017.9-3.9"
-                  />
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
-                  />
-                </svg>
-                <svg
-                  id="eye-closed-id_new_password2"
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="hidden w-6 h-6"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M17.94 17.94A9.99 9.99 0 0112 20C5 20 2 12 2 12s3-8 10-8c2.5 0 4.8.9 6.54 2.4"
-                  />
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    d="M9.88 9.88a3 3 0 014.24 4.24M3 3l18 18"
-                  />
-                </svg>
-              </span>
-            </div>
-          </div>
+    <main class="flex flex-col items-center justify-center flex-grow">
+      <div class="w-full max-w-md px-8 pt-6 pb-8 bg-white rounded-lg shadow-md">
+        <!-- Header -->
+        <div class="relative mb-4">
+          <h1 class="text-2xl font-bold text-center text-gray-700">
+            重置您的密碼
+          </h1>
         </div>
 
-        <button
-          type="submit"
-          class="w-full px-4 py-2 text-white bg-blue-600 rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-        >
-          修改密碼
-        </button>
-      </form>
+        <!-- Reset Password Form -->
+        <form method="post" class="space-y-6">
+          {% csrf_token %}
 
-      <p class="mt-4 text-sm text-center text-gray-600">
-        想起密碼了嗎？
-        <a href="{% url 'users:login' %}" class="text-blue-500 hover:underline"
-          >返回登入頁面</a
-        >
-      </p>
-    </div>
+          <div class="space-y-4">
+            <!-- New Password -->
+            <div>
+              <label
+                for="id_new_password1"
+                class="block text-sm font-medium text-gray-700"
+              >
+                新密碼：
+              </label>
+              <div class="relative">
+                <input
+                  type="password"
+                  name="new_password1"
+                  id="id_new_password1"
+                  class="w-full px-3 py-2 pr-10 mt-1 text-gray-700 placeholder-gray-400 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                  placeholder="新密碼須包含英文及數字"
+                  required
+                />
+                <span
+                  onclick="togglePassword('id_new_password1')"
+                  class="absolute inset-y-0 flex items-center text-gray-500 cursor-pointer right-3 hover:text-gray-700"
+                >
+                  <svg
+                    id="eye-open-id_new_password1"
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="w-6 h-6"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M15.9 15.9A6 6 0 018 12a6 6 0 017.9-3.9"
+                    />
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
+                    />
+                  </svg>
+                  <svg
+                    id="eye-closed-id_new_password1"
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="hidden w-6 h-6"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M17.94 17.94A9.99 9.99 0 0112 20C5 20 2 12 2 12s3-8 10-8c2.5 0 4.8.9 6.54 2.4"
+                    />
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M9.88 9.88a3 3 0 014.24 4.24M3 3l18 18"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
 
-    <!-- Footer -->
-    <footer
-      class="absolute bottom-0 left-0 right-0 flex justify-center py-2 text-center text-white bg-black"
-    >
-      <p>&copy; 2025 PicTrace. All rights reserved.</p>
-    </footer>
+            <!-- Confirm New Password -->
+            <div>
+              <label
+                for="id_new_password2"
+                class="block text-sm font-medium text-gray-700"
+              >
+                新密碼確認：
+              </label>
+              <div class="relative">
+                <input
+                  type="password"
+                  name="new_password2"
+                  id="id_new_password2"
+                  class="w-full px-3 py-2 pr-10 mt-1 text-gray-700 placeholder-gray-400 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                  placeholder="請再次輸入新密碼"
+                  required
+                />
+                <span
+                  onclick="togglePassword('id_new_password2')"
+                  class="absolute inset-y-0 flex items-center text-gray-500 cursor-pointer right-3 hover:text-gray-700"
+                >
+                  <svg
+                    id="eye-open-id_new_password2"
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="w-6 h-6"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M15.9 15.9A6 6 0 018 12a6 6 0 017.9-3.9"
+                    />
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
+                    />
+                  </svg>
+                  <svg
+                    id="eye-closed-id_new_password2"
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="hidden w-6 h-6"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M17.94 17.94A9.99 9.99 0 0112 20C5 20 2 12 2 12s3-8 10-8c2.5 0 4.8.9 6.54 2.4"
+                    />
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M9.88 9.88a3 3 0 014.24 4.24M3 3l18 18"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            class="w-full px-4 py-2 text-white bg-blue-600 rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            修改密碼
+          </button>
+        </form>
+
+        <p class="mt-4 text-sm text-center text-gray-600">
+          想起密碼了嗎？
+          <a
+            href="{% url 'users:login' %}"
+            class="text-blue-500 hover:underline"
+            >返回登入頁面</a
+          >
+        </p>
+      </div>
+    </main>
+
+    {% include "shared/footer.html" %}
 
     <!-- JavaScript for Toggle Password -->
     <script>

--- a/users/templates/users/password_reset_done.html
+++ b/users/templates/users/password_reset_done.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-TW">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,40 +7,39 @@
     {% load static %}
     <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
   </head>
-  {% include "shared/navbar2.html" %}
+
   <body
-    class="flex flex-col items-center justify-center min-h-screen bg-center bg-cover pt-14"
+    class="flex flex-col min-h-screen pt-16 bg-center bg-cover"
     style="background-image: url('{% static 'images/background.jpg' %}')"
   >
-    <div
-      class="w-full max-w-md px-8 pt-6 pb-8 mb-4 bg-white rounded-lg shadow-md"
-    >
-      <!-- Header with back arrow and title -->
-      <div class="relative mb-4">
-        <!-- Success Title -->
-        <h1 class="text-2xl font-bold text-center text-gray-700">
-          密碼重置連結發送成功
-        </h1>
+    {% include "shared/navbar2.html" %}
+
+    <main class="flex flex-col items-center justify-center flex-grow">
+      <div class="w-full max-w-md px-8 pt-6 pb-8 bg-white rounded-lg shadow-md">
+        <!-- Header -->
+        <div class="relative mb-4">
+          <h1 class="text-2xl font-bold text-center text-gray-700">
+            密碼重置連結發送成功
+          </h1>
+        </div>
+
+        <!-- Success Message -->
+        <div class="mb-4 text-center text-gray-700">
+          <p class="text-lg">請確認您的信箱。</p>
+        </div>
+
+        <!-- Login Button -->
+        <div class="mt-6 text-center">
+          <a
+            href="{% url 'users:login' %}"
+            class="px-4 py-2 font-bold text-white bg-blue-600 rounded hover:bg-blue-700 focus:outline-none focus:shadow-outline"
+          >
+            返回登入頁面
+          </a>
+        </div>
       </div>
-      <!-- Success Message -->
-      <div class="mb-4 text-center text-gray-700">
-        <p class="text-lg">請確認您的信箱。</p>
-      </div>
-      <!-- Login Button -->
-      <div class="mt-6 text-center">
-        <a
-          href="{% url 'users:login' %}"
-          class="px-4 py-2 font-bold text-white bg-blue-600 rounded hover:bg-blue-700 focus:outline-none focus:shadow-outline"
-        >
-          返回登入頁面
-        </a>
-      </div>
-    </div>
-    <!-- Footer -->
-    <footer
-      class="absolute bottom-0 left-0 right-0 flex justify-center py-2 text-center text-white bg-black"
-    >
-      <p>&copy; 2025 PicTrace. All rights reserved.</p>
-    </footer>
+    </main>
+
+    {% include "shared/footer.html" %}
   </body>
 </html>

--- a/users/templates/users/register.html
+++ b/users/templates/users/register.html
@@ -8,243 +8,244 @@
     <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
   </head>
 
-  {% include "shared/navbar2.html" %}
-
   <body
-    class="flex flex-col items-center justify-center min-h-screen bg-center bg-cover pt-14"
+    class="flex flex-col min-h-screen pt-16 bg-center bg-cover"
     style="background-image: url('{% static 'images/background.jpg' %}')"
   >
-    <div
-      class="w-full max-w-md px-8 pt-6 pb-2 mb-4 bg-white rounded-lg shadow-md"
-    >
-      <!-- Header -->
-      <div class="relative mb-4">
-        <a
-          href="{% url 'home:home' %}"
-          class="absolute left-0 flex items-center text-gray-600 transform -translate-y-1/2 top-1/2 hover:text-blue-800"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="w-8 h-8"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            viewBox="0 0 24 24"
+    {% include "shared/navbar2.html" %}
+
+    <main class="flex flex-col items-center justify-center flex-grow">
+      <div class="w-full max-w-md px-8 pt-6 pb-2 bg-white rounded-lg shadow-md">
+        <!-- Header -->
+        <div class="relative mb-4">
+          <a
+            href="{% url 'home:home' %}"
+            class="absolute left-0 flex items-center text-gray-600 transform -translate-y-1/2 top-1/2 hover:text-blue-800"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M19 12H5" />
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M12 5l-7 7 7 7"
-            />
-          </svg>
-        </a>
-        <h1 class="text-2xl font-bold text-center text-gray-700">註冊帳號</h1>
-      </div>
-
-      <!-- Error Messages -->
-      {% if form.errors %}
-      <div class="p-4 mb-4 text-red-700 bg-red-100 rounded-lg">
-        <ul>
-          <!-- 顯示表單的非欄位錯誤 -->
-          {% for error in form.non_field_errors %}
-          <li>{{ error }}</li>
-          {% endfor %}
-
-          <!-- 顯示每個欄位的錯誤，只顯示一次 -->
-          {% for field, errors in form.errors.items %} {% if errors %}
-          <li>{{ errors.0 }}</li>
-          <!-- 只顯示第一個錯誤，避免重複 -->
-          {% endif %} {% endfor %}
-        </ul>
-      </div>
-      {% endif %}
-
-      <form method="post" action="{% url 'users:register' %}">
-        {% csrf_token %}
-
-        <!-- Username -->
-        <div class="mb-4">
-          <label
-            for="username"
-            class="block mb-2 text-sm font-bold text-gray-700"
-            >用戶名</label
-          >
-          <input
-            type="text"
-            name="username"
-            id="username"
-            class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
-            value="{{ form.username.value|default_if_none:'' }}"
-            required
-          />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="w-8 h-8"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M19 12H5"
+              />
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M12 5l-7 7 7 7"
+              />
+            </svg>
+          </a>
+          <h1 class="text-2xl font-bold text-center text-gray-700">註冊帳號</h1>
         </div>
 
-        <!-- Email -->
-        <div class="mb-4">
-          <label for="email" class="block mb-2 text-sm font-bold text-gray-700"
-            >信箱</label
-          >
-          <input
-            type="email"
-            name="email"
-            id="email"
-            class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
-            value="{{ form.email.value|default_if_none:'' }}"
-            required
-          />
+        <!-- ✅ 修正錯誤訊息 -->
+        {% if form.errors %}
+        <div class="p-4 mb-4 text-red-700 bg-red-100 rounded-lg">
+          <ul>
+            {% for error in form.non_field_errors %}
+            <li>{{ error }}</li>
+            {% endfor %} {% for field in form %} {% for error in field.errors %}
+            <li>{{ error }}</li>
+            {% endfor %} {% endfor %}
+          </ul>
         </div>
+        {% endif %}
 
-        <!-- Password -->
-        <div class="mb-6">
-          <label
-            for="password1"
-            class="block mb-2 text-sm font-bold text-gray-700"
-            >密碼</label
-          >
-          <div class="relative">
+        <form method="post" action="{% url 'users:register' %}">
+          {% csrf_token %}
+
+          <!-- Username -->
+          <div class="mb-4">
+            <label
+              for="username"
+              class="block mb-2 text-sm font-bold text-gray-700"
+              >用戶名</label
+            >
             <input
-              type="password"
-              name="password1"
-              id="password1"
-              placeholder="密碼須包含英文及數字"
-              class="w-full px-3 py-2 pr-10 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
+              type="text"
+              name="username"
+              id="username"
+              class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
+              value="{{ form.username.value|default_if_none:'' }}"
               required
-              minlength="8"
             />
-            <span
-              onclick="togglePassword('password1')"
-              class="absolute inset-y-0 flex items-center text-gray-500 cursor-pointer right-3 hover:text-gray-700"
-            >
-              <svg
-                id="eye-open-password1"
-                xmlns="http://www.w3.org/2000/svg"
-                class="w-6 h-6"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M15.9 15.9A6 6 0 018 12a6 6 0 017.9-3.9"
-                />
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
-                />
-              </svg>
-              <svg
-                id="eye-closed-password1"
-                xmlns="http://www.w3.org/2000/svg"
-                class="hidden w-6 h-6"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M17.94 17.94A9.99 9.99 0 0112 20C5 20 2 12 2 12s3-8 10-8c2.5 0 4.8.9 6.54 2.4"
-                />
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M9.88 9.88a3 3 0 014.24 4.24M3 3l18 18"
-                />
-              </svg>
-            </span>
           </div>
-        </div>
 
-        <!-- Confirm Password -->
-        <div class="mb-6">
-          <label
-            for="password2"
-            class="block mb-2 text-sm font-bold text-gray-700"
-            >確認密碼</label
-          >
-          <div class="relative">
+          <!-- Email -->
+          <div class="mb-4">
+            <label
+              for="email"
+              class="block mb-2 text-sm font-bold text-gray-700"
+              >信箱</label
+            >
             <input
-              type="password"
-              name="password2"
-              id="password2"
-              placeholder="請再次輸入密碼"
-              class="w-full px-3 py-2 pr-10 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
+              type="email"
+              name="email"
+              id="email"
+              class="w-full px-3 py-2 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
+              value="{{ form.email.value|default_if_none:'' }}"
               required
-              minlength="8"
             />
-            <span
-              onclick="togglePassword('password2')"
-              class="absolute inset-y-0 flex items-center text-gray-500 cursor-pointer right-3 hover:text-gray-700"
-            >
-              <svg
-                id="eye-open-password2"
-                xmlns="http://www.w3.org/2000/svg"
-                class="w-6 h-6"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M15.9 15.9A6 6 0 018 12a6 6 0 017.9-3.9"
-                />
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
-                />
-              </svg>
-              <svg
-                id="eye-closed-password2"
-                xmlns="http://www.w3.org/2000/svg"
-                class="hidden w-6 h-6"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M17.94 17.94A9.99 9.99 0 0112 20C5 20 2 12 2 12s3-8 10-8c2.5 0 4.8.9 6.54 2.4"
-                />
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M9.88 9.88a3 3 0 014.24 4.24M3 3l18 18"
-                />
-              </svg>
-            </span>
           </div>
-        </div>
-        <button
-          type="submit"
-          class="w-full px-4 py-2 text-white bg-blue-600 rounded-lg hover:bg-blue-500"
-        >
-          註冊
-        </button>
-        <!-- 分隔線 -->
-        <hr class="my-4 border-gray-500 border-1" />
 
-        <div class="text-center">
-          <p class="px-4 text-gray-500">
-            已經有帳號？
-            <a
-              href="{% url 'users:login' %}"
-              class="text-blue-600 hover:underline"
-              >登入</a
+          <!-- Password -->
+          <div class="mb-6">
+            <label
+              for="password1"
+              class="block mb-2 text-sm font-bold text-gray-700"
+              >密碼</label
             >
-          </p>
-        </div>
-      </form>
-    </div>
+            <div class="relative">
+              <input
+                type="password"
+                name="password1"
+                id="password1"
+                placeholder="密碼須包含英文及數字"
+                class="w-full px-3 py-2 pr-10 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
+                required
+                minlength="8"
+              />
+              <span
+                onclick="togglePassword('password1')"
+                class="absolute inset-y-0 flex items-center text-gray-500 cursor-pointer right-3 hover:text-gray-700"
+              >
+                <svg
+                  id="eye-open-password1"
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M15.9 15.9A6 6 0 018 12a6 6 0 017.9-3.9"
+                  />
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
+                  />
+                </svg>
+                <svg
+                  id="eye-closed-password1"
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="hidden w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M17.94 17.94A9.99 9.99 0 0112 20C5 20 2 12 2 12s3-8 10-8c2.5 0 4.8.9 6.54 2.4"
+                  />
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M9.88 9.88a3 3 0 014.24 4.24M3 3l18 18"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+
+          <!-- Confirm Password -->
+          <div class="mb-6">
+            <label
+              for="password2"
+              class="block mb-2 text-sm font-bold text-gray-700"
+              >確認密碼</label
+            >
+            <div class="relative">
+              <input
+                type="password"
+                name="password2"
+                id="password2"
+                placeholder="請再次輸入密碼"
+                class="w-full px-3 py-2 pr-10 leading-tight text-gray-700 border rounded shadow appearance-none focus:outline-none focus:shadow-outline"
+                required
+                minlength="8"
+              />
+              <span
+                onclick="togglePassword('password2')"
+                class="absolute inset-y-0 flex items-center text-gray-500 cursor-pointer right-3 hover:text-gray-700"
+              >
+                <svg
+                  id="eye-open-password2"
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M15.9 15.9A6 6 0 018 12a6 6 0 017.9-3.9"
+                  />
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z"
+                  />
+                </svg>
+                <svg
+                  id="eye-closed-password2"
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="hidden w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M17.94 17.94A9.99 9.99 0 0112 20C5 20 2 12 2 12s3-8 10-8c2.5 0 4.8.9 6.54 2.4"
+                  />
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M9.88 9.88a3 3 0 014.24 4.24M3 3l18 18"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            class="w-full px-4 py-2 font-bold text-white bg-blue-600 rounded hover:bg-blue-700 focus:outline-none focus:shadow-outline"
+          >
+            註冊
+          </button>
+
+          <div class="mt-4 text-center">
+            <p class="text-gray-500">
+              已經有帳號？<a
+                href="{% url 'users:login' %}"
+                class="text-blue-600 hover:underline"
+                >登入</a
+              >
+            </p>
+          </div>
+        </form>
+      </div>
+    </main>
+
+    {% include "shared/footer.html" %}
 
     <script>
       function togglePassword(id) {


### PR DESCRIPTION
## 變更內容
1. 抽離 Footer 模板

- 原本每個頁面各自擁有獨立的 Footer，現在將其統一抽離至 templates/shared/footer.html，提高可重用性與維護性。
- 透過 {% include "shared/footer.html" %} 方式嵌入到所有頁面。

2. 優化 Footer 響應式設計

- 使 Footer 不再遮擋網頁內容，確保無論裝置大小皆能正確顯示。
- 允許 Footer 根據裝置高度自適應位置，使其能隨頁面滾動。

3. 修改相關模板文件

- 更新 layout.html，以確保 Footer 能夠被正確載入。
- 修正 home.html、check_email.html、login.html、register.html 等頁面，使其適配新的 Footer 設計。

## 變更原因

- 先前 Footer 需在每個頁面單獨定義，造成代碼冗餘且難以統一管理。
- 原本 Footer 可能會遮擋部分網頁內容，影響使用體驗，特別是在小螢幕裝置上。

## 影響範圍

- 影響所有包含 Footer 的頁面，具體包含：
  - home.html
  - check_email.html
  - login.html
  - register.html
  - password_reset.html
  - password_reset_confirm.html
  - password_reset_done.html
  - password_reset_complete.html

## 測試方式
1. 檢查 Footer 是否正確載入

- 確保所有頁面均能正常引入 shared/footer.html 並顯示內容。

2. 驗證響應式行為

- 測試不同裝置尺寸，確認 Footer 位置正確，且不會遮擋主要內容。

3. 檢查滾動行為

- 確保頁面滾動時，Footer 能隨頁面適當位置變動，而不影響內容可讀性。