### PR TITLE
[fix]將 navbar 從 fixed 改為 sticky 以防止內容重疊

### DIFF
--- a/templates/shared/footer.html
+++ b/templates/shared/footer.html
@@ -1,5 +1,3 @@
-<footer
-  class="flex justify-center w-full py-2 mt-auto text-center text-white bg-black"
->
+<footer class="sticky bottom-0 w-full py-2 text-center text-white bg-black">
   <p>&copy; 2025 PicTrace. All rights reserved.</p>
 </footer>

--- a/templates/shared/navbar.html
+++ b/templates/shared/navbar.html
@@ -1,6 +1,6 @@
 {% load static %}
 <!-- Header -->
-<header class="fixed top-0 left-0 z-50 w-full bg-black shadow-md h-14">
+<header class="sticky top-0 left-0 z-50 w-full bg-black shadow-md h-14">
   <div class="flex items-center justify-between h-full px-4 mx-auto max-w-7xl">
     <!-- Left Section: Logo -->
     <div class="flex items-center space-x-2">

--- a/templates/shared/navbar2.html
+++ b/templates/shared/navbar2.html
@@ -1,6 +1,6 @@
 {% load static %}
 <!-- Header -->
-<header class="fixed top-0 left-0 z-50 w-full bg-black shadow-md h-14">
+<header class="sticky top-0 left-0 z-50 w-full bg-black shadow-md h-14">
   <div class="flex items-center justify-between h-full px-4 mx-auto max-w-7xl">
     <!-- Left Section: Logo -->
     <div class="flex items-center space-x-2">


### PR DESCRIPTION
#### 變更內容
- **修改 `navbar.html` 與 `navbar2.html`**
  - 將 `<header>` 的 `class` 屬性從 `fixed` 變更為 `sticky`，確保導覽列不會覆蓋內容，並仍保持在頁面頂部。
- **調整 `footer.html`**
  - 修正 `footer` 樣式，設定為 `sticky bottom-0`，確保頁尾固定在頁面底部，不會影響主要內容區域。

#### 影響範圍
- **所有使用 navbar 的頁面**，調整後可防止內容被 `fixed` 導覽列遮擋，提升可讀性與 UX。
- **頁尾樣式調整**，確保 footer 不會因 `fixed` 影響頁面佈局。

#### 測試方式
1. **開啟網站並滾動頁面**：
   - 確保 `navbar` 不會遮擋內容，但仍保持在頂部。
   - 確保 `footer` 在頁面底部，並不會影響主要內容的顯示。
2. **在不同解析度下測試**：
   - 確保 `sticky` 行為在桌面端與行動端均正常運行。

#### 修正動機
- 先前使用 `fixed` 會導致內容被 `navbar` 遮住，影響使用體驗，因此改為 `sticky` 以確保正常顯示。

#### 其他備註
- 此變更不影響功能邏輯，只影響前端 UI 佈局。