### PR TITLE
[feat]: 優化使用者頭像顯示與上傳 UI，並改進錯誤訊息

### DIFF
--- a/templates/shared/profile.html
+++ b/templates/shared/profile.html
@@ -1,4 +1,4 @@
-{% extends "shared/layout.html" %} {% block content %}
+{% extends "shared/layout.html" %} {% block content %}{% load static %}
 <div
   class="profile-header"
   style="background: url('{{ background_url|default:'/static/images/profile-background.webp' }}') center/cover no-repeat; padding: 50px 20px; text-align: center; color: white;"
@@ -8,9 +8,10 @@
       href="{% url 'users:upload_avatar' %}"
       style="display: block; position: relative"
     >
+      {% if user.profile.avatar %}
       <img
-        src="{{ avatar_url|default:'/static/images/user-avatar.png' }}"
-        alt="Avatar"
+        src="{{ user.profile.avatar }}"
+        alt="User Avatar"
         style="
           width: 100px;
           height: 100px;
@@ -20,6 +21,20 @@
         "
         class="avatar-image"
       />
+      {% else %}
+      <img
+        src="{% static 'images/user-avatar.png' %}"
+        alt="User Avatar"
+        style="
+          width: 100px;
+          height: 100px;
+          border-radius: 50%;
+          border: 3px solid white;
+          transition: opacity 0.3s ease-in-out;
+        "
+        class="avatar-image"
+      />
+      {% endif %}
     </a>
   </div>
   <h1

--- a/users/templates/users/profile.html
+++ b/users/templates/users/profile.html
@@ -1,7 +1,7 @@
 {% extends "shared/profile.html" %} {% block profile %}
 
 <div class="profile-content" style="text-align: center; padding: 20px">
-  <h2>Welcome to your profile page, {{ request.user.username }}!</h2>
+  <h2>歡迎回來！ {{ request.user.username }}!</h2>
 </div>
 
 {% endblock %}

--- a/users/templates/users/upload_avatar.html
+++ b/users/templates/users/upload_avatar.html
@@ -1,12 +1,35 @@
-<form method="POST" enctype="multipart/form-data">
-  {% csrf_token %} {{ form.as_p }}
-  <button type="submit">上傳大頭貼</button>
-</form>
+{% extends "shared/layout.html" %} {% block content %}{% load static %}
+<div class="flex flex-col items-center justify-center min-h-screen py-10">
+  <div class="w-full max-w-lg p-8 bg-white rounded-lg shadow-xl">
+    <h2 class="mb-4 text-3xl font-extrabold text-center text-gray-900">
+      編輯個人資訊
+    </h2>
+    <p class="mb-6 text-center text-gray-600">請更新您的大頭貼</p>
 
-{% if messages %}
-<ul>
-  {% for message in messages %}
-  <li class="message {{ message.tags }}">{{ message }}</li>
-  {% endfor %}
-</ul>
-{% endif %}
+    <form method="POST" enctype="multipart/form-data" class="space-y-6">
+      {% csrf_token %}
+
+      <div class="flex flex-col items-center space-y-4">{{ form.avatar }}</div>
+
+      <button
+        type="submit"
+        class="w-full py-3 font-semibold text-white transition duration-300 bg-blue-600 rounded-lg shadow-lg hover:bg-blue-700"
+      >
+        更新資訊
+      </button>
+    </form>
+
+    {% if messages %}
+    <div class="mt-6">
+      {% for message in messages %}
+      <div
+        class="p-4 rounded-lg text-white font-medium shadow-md text-center {% if message.tags == 'success' %} bg-green-500 {% elif message.tags == 'error' %} bg-red-500 {% else %} bg-gray-600 {% endif %}"
+      >
+        {{ message }}
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/users/views.py
+++ b/users/views.py
@@ -179,7 +179,7 @@ def upload_avatar(request):
 
         # 檢查檔案大小 (限制 5 MB)
         if avatar.size > 5 * 1024 * 1024:
-            messages.error(request, "The file size exceeds the 5MB limit.")
+            messages.error(request, "檔案大小不能超過 5 MB")
             return redirect("users:upload_avatar")
 
         # 檢查檔案類型 (僅允許 JPEG 和 PNG)
@@ -187,7 +187,7 @@ def upload_avatar(request):
             "image/jpeg",
             "image/png",
         ]:
-            messages.error(request, "Only JPEG and PNG files are allowed.")
+            messages.error(request, " 只能上傳 JPEG 或 PNG 格式的圖片")
             return redirect("users:upload_avatar")
 
         # 上傳檔案到 S3
@@ -199,9 +199,9 @@ def upload_avatar(request):
             user_profile.avatar = file_url
             user_profile.save()
 
-            messages.success(request, "Avatar uploaded successfully!")
+            messages.success(request, "頭像上傳成功！")
         else:
-            messages.error(request, "Failed to upload avatar. Please try again.")
+            messages.error(request, "頭像上傳失敗，請稍後再試")
 
         return redirect("users:profile")
 


### PR DESCRIPTION
#### 變更內容
- **使用者頭像顯示**
  - 變更 `avatar` 預設顯示方式，改為：
    - 若使用者有上傳頭像，則顯示 `user.profile.avatar`
    - 若無上傳頭像，則使用預設的 `user-avatar.png`
- **使用者頭像上傳 UI 改進**
  - 重新設計 `upload_avatar.html`，提升排版與使用者體驗：
    - 新增標題與描述，引導使用者上傳頭像
    - 使用 `flex` 佈局優化按鈕與輸入框
    - 提供更清楚的錯誤訊息區塊，提示使用者上傳狀態
- **改善錯誤訊息**
  - 修正檔案大小超過 5MB 限制的錯誤訊息，改為更清楚的中文提示
  - 修正檔案格式錯誤時的錯誤訊息，限定為 `JPEG` 與 `PNG`
  - 變更成功與失敗的上傳訊息，提升可讀性

#### 影響範圍
- **使用者個人資料頁面 (`profile.html`)**
  - 變更頭像顯示方式，使其根據使用者是否有上傳頭像來決定顯示圖片
- **使用者頭像上傳頁面 (`upload_avatar.html`)**
  - 重新設計 UI，使上傳過程更直覺
  - 確保使用者可獲得適當的回饋訊息
- **後端 `views.py`**
  - 修正上傳流程，確保使用者在上傳失敗時可獲得適當的提示

#### 測試方式
1. **測試頭像顯示邏輯**
   - 在未上傳頭像的情況下，應顯示預設 `user-avatar.png`
   - 在上傳新頭像後，應顯示最新的 `user.profile.avatar`
2. **測試錯誤處理**
   - 嘗試上傳超過 5MB 的圖片，應顯示 `"檔案大小不能超過 5MB"`
   - 嘗試上傳非 `JPEG` 或 `PNG` 格式的圖片，應顯示 `"只能上傳 JPEG 或 PNG 格式的圖片"`
   - 成功上傳時應顯示 `"頭像上傳成功！"`

#### 修正動機
- 目前上傳頭像的 UI 不夠直覺，缺乏明確的提示與錯誤訊息
- 部分使用者上傳錯誤時，沒有清楚的回饋，導致使用體驗不佳
- 透過這次改進，提升系統可用性，使使用者可以順利上傳與管理頭像

#### 其他備註
- 這次 PR 主要影響前端 UI 及部分後端邏輯，與其他功能無衝突
