### PR TITLE
[feat]改進貼文按鈕 UI 並優化圖片上傳回應

### DIFF
--- a/home/templates/home/home.html
+++ b/home/templates/home/home.html
@@ -1,28 +1,41 @@
-{% extends "shared/layout.html" %} {% load static %} {% block content %}
-<div class="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
+{% extends "shared/layout.html" %} 
+{% load static %} 
+
+{% block content %}
+<div class="px-4 mx-auto max-w-7xl sm:px-6 lg:px-8" x-data="postModal()">
   <h1 class="mb-8 text-4xl font-bold text-center">歡迎來到 PicTrace！</h1>
 
-  <!-- Features Section -->
-  <section class="grid grid-cols-1 gap-12 md:grid-cols-2 lg:grid-cols-3">
-    <div class="p-6 bg-white rounded-lg shadow-lg">
-      <h2 class="text-2xl font-semibold">發現台灣景點</h2>
-      <p class="mt-4 text-gray-600">
-        在地標註你拍攝過的景點，並探索更多美麗的場所。
-      </p>
+  <!-- 發文按鈕 -->
+  <div class="flex justify-center mb-6">
+    <button @click="isPostModalOpen = true" class="px-4 py-2 text-white bg-blue-500 rounded-lg">
+      新增貼文
+    </button>
+  </div>
+
+  <!-- 發文 Modal 視窗 -->
+  <div x-show="isPostModalOpen" class="fixed inset-0 flex items-center justify-center bg-gray-900 bg-opacity-50">
+    <div class="p-6 bg-white rounded-lg shadow-lg w-96">
+      <h2 class="mb-4 text-xl font-bold">新增貼文</h2>
+      <form @submit.prevent="submitPost">
+        {% csrf_token %}
+        <label class="block mb-2">標題：</label>
+        <input type="text" x-model="postTitle" class="w-full px-3 py-2 mb-3 border rounded-md" required>
+
+        <label class="block mb-2">內容：</label>
+        <textarea x-model="postContent" class="w-full px-3 py-2 mb-3 border rounded-md" required></textarea>
+
+        <label class="block mb-2">圖片：</label>
+        <input type="file" @change="handleFileUpload" class="mb-3">
+
+        <div class="flex justify-end">
+          <button type="button" @click="isPostModalOpen = false" class="px-4 py-2 mr-2 text-gray-600 bg-gray-300 rounded-lg">
+            取消
+          </button>
+          <button type="submit" class="px-4 py-2 text-white bg-blue-500 rounded-lg">發布</button>
+        </div>
+      </form>
     </div>
-    <div class="p-6 bg-white rounded-lg shadow-lg">
-      <h2 class="text-2xl font-semibold">照片分享</h2>
-      <p class="mt-4 text-gray-600">
-        將你的照片上傳與社群分享，建立自己的影像庫。
-      </p>
-    </div>
-    <div class="p-6 bg-white rounded-lg shadow-lg">
-      <h2 class="text-2xl font-semibold">用戶活動</h2>
-      <p class="mt-4 text-gray-600">
-        參與我們的拍攝主題活動，並有機會贏得獎品。
-      </p>
-    </div>
-  </section>
+  </div>
 
   <!-- 最新貼文 -->
   <section class="mt-12">
@@ -37,7 +50,7 @@
         <h3 class="mt-4 text-lg font-semibold">{{ post.title }}</h3>
         <p class="text-gray-600">{{ post.content|truncatechars:50 }}</p>
         <p class="text-sm text-gray-500">
-          由 {{ post.author.username }}發布於 {{ post.created_at|timesince }} 前
+          由 {{ post.author.username }} 發布於 {{ post.created_at|timesince }} 前
         </p>
       </div>
       {% endfor %}
@@ -47,4 +60,55 @@
     {% endif %}
   </section>
 </div>
+
+<!-- Alpine.js 前端邏輯 -->
+<script>
+  document.addEventListener("alpine:init", () => {
+      Alpine.data("postModal", () => ({
+          isPostModalOpen: false,
+          postTitle: "",
+          postContent: "",
+          imageFile: null,
+  
+          handleFileUpload(event) {
+              this.imageFile = event.target.files[0];
+          },
+  
+          async submitPost() {
+              if (!this.postTitle || !this.postContent) {
+                  alert("標題和內容不可為空！");
+                  return;
+              }
+  
+              let formData = new FormData();
+              formData.append("title", this.postTitle);
+              formData.append("content", this.postContent);
+              if (this.imageFile) {
+                  formData.append("image", this.imageFile);
+              }
+  
+              try {
+                  const response = await fetch("{% url 'posts:create_post' %}", {
+                      method: "POST",
+                      headers: {
+                          "X-CSRFToken": "{{ csrf_token }}"
+                      },
+                      body: formData
+                  });
+  
+                  if (response.ok) {
+                      location.reload(); // 成功後重新整理頁面
+                  } else {
+                      alert("發文失敗，請重試");
+                  }
+              } catch (error) {
+                  console.error("發生錯誤：", error);
+                  alert("發文時發生錯誤！");
+              }
+          }
+      }));
+  });
+  </script>
+  
+
 {% endblock %}

--- a/templates/shared/layout.html
+++ b/templates/shared/layout.html
@@ -6,6 +6,10 @@
     <title>PicTrace</title>
     {% load static %}
     <link href="{% static 'css/tailwind.css' %}" rel="stylesheet" />
+
+    <!-- ✅ 引入 Alpine.js CDN -->
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+
   </head>
   <body class="flex flex-col min-h-screen">
     {% include "shared/navbar.html" %}


### PR DESCRIPTION
#### 變更內容
- **新增 Alpine.js 前端框架**
  - 在 `layout.html` 加入 Alpine.js CDN，以支援互動行為。

- **更新 `home.html`**
  - 增加發文按鈕，點擊後彈出對話框，允許使用者直接輸入貼文內容並上傳圖片。
  - 調整排版，確保 UI 更直覺。

- **後端 `views.py`**
  - 將 `create_post` API 回應格式統一，使用 `JsonResponse` 回應成功或錯誤訊息。
  - 新增檔案大小與格式驗證，防止上傳不支援的圖片類型。
  - 若圖片符合條件，則上傳至 S3 並回傳 URL。

#### 影響範圍
- **前端 UI**
  - 貼文按鈕改為互動式模態視窗。
  - 使用者可更方便發佈內容，不須跳轉頁面。

- **後端 API**
  - `create_post` API 現在會回傳標準化的 JSON 回應，包含成功訊息與錯誤回應碼。

#### 測試方式
1. **點擊貼文按鈕**
   - 應彈出輸入框並允許使用者輸入文字與上傳圖片。
2. **上傳圖片測試**
   - 測試 JPEG/PNG 圖片是否成功上傳並顯示。
   - 測試大於 5MB 的圖片是否被阻擋並顯示錯誤訊息。
   - 測試非 JPEG/PNG 圖片是否被阻擋。

#### 修正動機
- 原本的 UI 需要跳轉頁面發文，體驗不流暢。
- 原本的 API 回應格式不一致，可能影響前端處理。

#### 其他備註
- 之後可擴展為支援即時貼文預覽。
- 目前僅優化發文，後續可調整貼文列表的 UI 來支援即時顯示新貼文。