### PR TITLE
[feat]新增文章編輯與刪除功能

### DIFF
--- a/home/templates/home/home.html
+++ b/home/templates/home/home.html
@@ -52,12 +52,24 @@
         <p class="text-sm text-gray-500">
           由 {{ post.author.username }} 發布於 {{ post.created_at|timesince }} 前
         </p>
+
+        <!-- 編輯與刪除按鈕：只有發文者能看到 -->
+        {% if user == post.author %}
+        <div class="flex justify-between mt-4">
+          <a href="{% url 'posts:edit_post' post.id %}" class="px-3 py-1 text-sm text-white bg-green-500 rounded hover:bg-green-600">編輯</a>
+          <form action="{% url 'posts:delete_post' post.id %}" method="POST" onsubmit="return confirm('確定要刪除這篇貼文嗎？');">
+            {% csrf_token %}
+            <button type="submit" class="px-3 py-1 text-sm text-white bg-red-500 rounded hover:bg-red-600">刪除</button>
+          </form>
+        </div>
+        {% endif %}
       </div>
       {% endfor %}
     </div>
     {% else %}
     <p class="mt-4 text-center text-gray-500">目前沒有貼文。</p>
     {% endif %}
+    
   </section>
 </div>
 
@@ -108,7 +120,6 @@
           }
       }));
   });
-  </script>
-  
+</script>
 
 {% endblock %}

--- a/posts/templates/posts/confirm_delete.html
+++ b/posts/templates/posts/confirm_delete.html
@@ -1,0 +1,8 @@
+<h2>確定要刪除此貼文嗎？</h2>
+<p>{{ post.title }}</p>
+
+<form method="POST">
+    {% csrf_token %}
+    <button type="submit">確定刪除</button>
+    <a href="{% url 'home:home' %}">取消</a>
+</form>

--- a/posts/templates/posts/edit_post.html
+++ b/posts/templates/posts/edit_post.html
@@ -1,0 +1,10 @@
+<h2>編輯貼文</h2>
+<form method="POST" enctype="multipart/form-data">
+    {% csrf_token %}
+    {{ form.as_p }}
+
+    <label for="image">更換圖片：</label>
+    <input type="file" name="image">
+
+    <button type="submit">更新</button>
+</form>

--- a/posts/urls.py
+++ b/posts/urls.py
@@ -1,8 +1,10 @@
 from django.urls import path
-from .views import create_post
+from .views import create_post, edit_post, delete_post
 
 app_name = "posts"
 
 urlpatterns = [
-    path("new/", create_post, name="create_post"),  # 設定新增貼文路由
+    path("new/", create_post, name="create_post"),  # 新增貼文
+    path("<int:post_id>/edit/", edit_post, name="edit_post"),  # 編輯貼文
+    path("<int:post_id>/delete/", delete_post, name="delete_post"),  # 刪除貼文
 ]

--- a/posts/views.py
+++ b/posts/views.py
@@ -1,9 +1,10 @@
-from django.http import JsonResponse
-from django.shortcuts import render, redirect
+from django.http import JsonResponse, HttpResponseForbidden
+from django.shortcuts import render, redirect, get_object_or_404
 from .models import Post
 from .forms import PostForm
 from users.utils import upload_to_s3
 from django.contrib.auth.decorators import login_required
+from django.contrib import messages
 
 
 @login_required
@@ -56,3 +57,74 @@ def create_post(request):
         form = PostForm()
 
     return render(request, "posts/create_post.html", {"form": form})
+
+
+# ✅ 編輯貼文
+@login_required
+def edit_post(request, post_id):
+    post = get_object_or_404(Post, id=post_id)
+
+    # 確保只能編輯自己的貼文
+    if post.author != request.user:
+        return HttpResponseForbidden("你無權限編輯這篇貼文。")
+
+    if request.method == "POST":
+        form = PostForm(request.POST, request.FILES, instance=post)
+        if form.is_valid():
+            edited_post = form.save(commit=False)
+            edited_post.author = request.user
+
+            # ✅ 如果有新圖片，則上傳至 S3
+            if request.FILES.get("image"):
+                image = request.FILES["image"]
+
+                # 檢查檔案大小 (限制 5MB)
+                if image.size > 5 * 1024 * 1024:
+                    messages.error(request, "圖片大小超過 5MB 限制")
+                    return redirect("home:home")
+
+                # 檢查檔案類型 (僅允許 JPEG 和 PNG)
+                if hasattr(image, "content_type") and image.content_type not in [
+                    "image/jpeg",
+                    "image/png",
+                ]:
+                    messages.error(request, "僅支援 JPEG 和 PNG 圖片格式")
+                    return redirect("home:home")
+
+                # 上傳新圖片至 S3
+                image.seek(0)
+                file_url = upload_to_s3(image)
+                if file_url:
+                    edited_post.image_url = file_url
+
+            edited_post.save()
+
+            # ✅ 加入成功訊息並跳轉回首頁
+            messages.success(request, "貼文已更新成功！")
+            return redirect("home:home")
+
+        # 如果表單驗證失敗
+        messages.error(request, "表單驗證失敗，請檢查輸入內容")
+        return redirect("home:home")
+
+    else:
+        form = PostForm(instance=post)
+
+    return render(request, "posts/edit_post.html", {"form": form, "post": post})
+
+
+# ✅ 刪除貼文
+@login_required
+def delete_post(request, post_id):
+    post = get_object_or_404(Post, id=post_id)
+
+    # 確保只能刪除自己的貼文
+    if post.author != request.user:
+        return HttpResponseForbidden("你無權限刪除這篇貼文。")
+
+    if request.method == "POST":
+        post.delete()
+        messages.success(request, "貼文已成功刪除！")  # ✅ 新增成功訊息
+        return redirect("home:home")  # ✅ 刪除後返回首頁
+
+    return render(request, "posts/confirm_delete.html", {"post": post})


### PR DESCRIPTION
#### 變更內容
- **新增文章編輯功能**
  - 在 `views.py` 中新增 `edit_post` 方法，允許使用者編輯自己的文章。
  - 新增 `posts/templates/posts/edit_post.html` 模板用於文章編輯表單。
  - 在 `home.html` 中為每篇文章增加編輯按鈕（僅限作者可見）。

- **新增文章刪除功能**
  - 在 `views.py` 中新增 `delete_post` 方法，允許使用者刪除自己的文章。
  - 新增 `posts/templates/posts/confirm_delete.html` 模板用於刪除確認頁面。
  - 在 `home.html` 中為每篇文章增加刪除按鈕（僅限作者可見）。

- **更新路由設定**
  - 在 `posts/urls.py` 中新增 `edit_post` 和 `delete_post` 的路由。

- **改善 UI/UX**
  - 在 `home.html` 為每篇文章顯示編輯與刪除按鈕。
  - 加入刪除確認對話框，避免誤刪文章。

#### 影響範圍
- **所有使用文章功能的頁面**：
  - 使用者現在可以編輯或刪除自己發布的文章。
  - 編輯與刪除按鈕僅對文章作者可見，其他使用者無法操作。

#### 測試方式
1. **文章編輯**
   - 登入並進入首頁。
   - 確認已發布文章旁邊出現「編輯」按鈕（僅限作者）。
   - 點擊「編輯」，修改內容並提交，確認變更成功。

2. **文章刪除**
   - 登入並進入首頁。
   - 確認已發布文章旁邊出現「刪除」按鈕（僅限作者）。
   - 點擊「刪除」，出現刪除確認頁面。
   - 確認刪除後，文章應從首頁移除。

3. **權限驗證**
   - 確認非文章作者無法看到編輯與刪除按鈕。
   - 嘗試透過網址直接存取編輯或刪除路由，確認系統阻止未授權操作。

#### 修正動機
- 提供使用者編輯與刪除已發布文章的功能，提升操作靈活性。
- 強化權限驗證，確保資料安全性。

#### 其他備註
- 已確認基本權限驗證功能正常。
- 尚未實作刪除後的提示訊息（可於後續 PR 補上）。

![image](https://github.com/user-attachments/assets/77154749-2d6c-4a9d-bf32-42adf3446756)

